### PR TITLE
Fix Git Attributes for Powershell

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,23 @@
 *.PDF diff=astextplain
 *.rtf diff=astextplain
 *.RTF diff=astextplain
+
+# From https://gist.github.com/KirkMunro/d873a755b38a7bfa2495
+# Explicitly declare text files we want to always be normalized and converted
+# to native line endings on checkout.
+*.md            text
+*.gitattributes text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.ps1    text  eol=crlf
+*.psm1   text  eol=crlf
+*.psd1   text  eol=crlf
+*.psc1   text  eol=crlf
+*.ps1xml text  eol=crlf
+*.clixml text  eol=crlf
+*.xml    text  eol=crlf
+*.txt    text  eol=crlf
+
+# Denote all files that are truly binary and should not be mergeable.
+*.dll binary
+*.exe binary


### PR DESCRIPTION
Current git thinks Powershell files are binary, see https://github.com/AITGmbH/ApplyCompanyPolicy.Template/commit/0e8fd902ed67e1933be35e507a87cdd2b8f4f252